### PR TITLE
Migrate to tree implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,49 @@
 # EasySlog
 
-EasySlog makes it easy to write custom formatters for slog by implementing the plumbing of the `slog.Handler` and exposes a simple interface to implement your own formatter.
+EasySlog makes it easy to write custom formatters for slog by implementing the plumbing of the `slog.Handler` and exposes a simple interface to implement your own formatter. This is less performant than writing a custom slog formatter, but it is much easier to write and test.
 
 The JSON formatter implemented in `easyslog_test.go` passes the `slogtest.TestHandler` tests and is a good example of how to implement a formatter.
 
 ## Usage
 
+To use EasySlog you need to implement the `easyslog.Formatter` interface and pass it to `easyslog.NewHandler`:
+
+```go
+Formatter interface {
+    Format(w io.Writer, r Record) error
+}
+```
+
+Here's an example of implementing a formatter:
+
 ```go
 type myFormatter struct{}
 
 func (f myFormatter) Format(w io.Writer, rec easyslog.Record) error {
-	attrs := make([]string, 0, len(rec.Attrs))
-	for _, attr := range rec.Attrs {
-		key := strings.Join(attr.Keys, ".")
-		attrs = append(attrs, fmt.Sprintf("%s=%s", key, attr.Value.String()))
-	}
+    attrs := make([]string, 0)
+    for _, attr := range rec.Attrs {
+        attrs = append(attrs, formatAttr(attr)...)
+    }
 
-	w.Write([]byte(fmt.Sprintf("%s %s %s %s\n", rec.Time, rec.Level, rec.Message, strings.Join(attrs, " "))))
-	return nil
+    w.Write([]byte(fmt.Sprintf("%s %s %s %s\n", rec.Time, rec.Level, rec.Message, strings.Join(attrs, " "))))
+    return nil
 }
 
-logger := slog.New(easyslog.New(os.Stdout, myFormatter{}, nil))
-logger.Debug("hello world", slog.String("foo", "bar"))
+func formatAttr(attr easyslog.Attr) []string {
+    if attr.IsGroup() {
+        attrs := make([]string, 0, len(attr.Children))
+
+        for _, child := range attr.Children {
+            attrs = append(attrs, formatAttr(child)...)
+        }
+        return attrs
+    }
+
+    return []string{fmt.Sprintf("%s=%s", attr.Key, attr.Value.String())}
+}
+
+// Usage:
+// slog.New(easyslog.NewHandler(myFormatter{}, nil))
 ```
 
 See also the `prettylog` package for a more complete example.

--- a/attr.go
+++ b/attr.go
@@ -1,0 +1,46 @@
+package easyslog
+
+import (
+	"log/slog"
+)
+
+type (
+	// Attr is a slog attribute that contains the key, the value, and a map of
+	// child attributes. Attr values that return true for `IsGroup` should not
+	// use the `Value` field and vice-versa.
+	Attr struct {
+		// The key of the attribute.
+		Key string
+		// The underlying slog.Value attribute being logged. `Resolve` is
+		// already called on values that implement `slog.LogValuer``.
+		Value slog.Value
+		// Children holds pointers to each of the nested attributes if they exist.
+		Children []*Attr
+	}
+)
+
+// Clone the existing tree for use in the formatter
+func (a *Attr) clone() *Attr {
+	attr := &Attr{
+		Key:      a.Key,
+		Value:    a.Value,
+		Children: make([]*Attr, len(a.Children)),
+	}
+
+	for i, child := range a.Children {
+		attr.Children[i] = child.clone()
+	}
+
+	return attr
+}
+
+// Returns true if this is a dead-end node and should not be rendered
+func (a *Attr) empty() bool {
+	return a.Value.Any() == nil && (a.Children == nil || len(a.Children) == 0)
+}
+
+// Returns true if this Attr represents a group and its Value field should be
+// ignored.
+func (a *Attr) IsGroup() bool {
+	return len(a.Children) > 0
+}

--- a/easyslog_test.go
+++ b/easyslog_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"testing/slogtest"
+
+	"github.com/stretchr/testify/require"
 )
 
 // Implement a JSON formatter to use with slogtest.TestHandler
@@ -16,26 +18,16 @@ type JSONFormatter struct{}
 var _ Formatter = (*JSONFormatter)(nil)
 
 func (formatter JSONFormatter) Format(w io.Writer, record Record) error {
-	result := map[string]any{
-		"msg":   record.Message,
-		"level": record.Level.String(),
-	}
+	result := make(map[string]any, len(record.Attrs))
+	result["msg"] = record.Message
+	result["level"] = record.Level.String()
 
 	if !record.Time.IsZero() {
 		result["time"] = record.Time
 	}
 
 	for _, attr := range record.Attrs {
-		writeTo := result
-		for _, key := range attr.Keys[:len(attr.Keys)-1] {
-			if _, ok := writeTo[key]; !ok {
-				writeTo[key] = map[string]any{}
-			}
-
-			writeTo = writeTo[key].(map[string]any)
-		}
-
-		writeTo[attr.Keys[len(attr.Keys)-1]] = attr.Value.String()
+		writeAttr(result, attr)
 	}
 
 	toWrite, err := json.Marshal(result)
@@ -44,6 +36,18 @@ func (formatter JSONFormatter) Format(w io.Writer, record Record) error {
 	}
 	_, _ = w.Write(toWrite)
 	return nil
+}
+
+func writeAttr(dst map[string]any, attr *Attr) {
+	if attr.Children == nil || len(attr.Children) == 0 {
+		dst[attr.Key] = attr.Value.String()
+		return
+	}
+
+	dst[attr.Key] = make(map[string]any)
+	for _, child := range attr.Children {
+		writeAttr(dst[attr.Key].(map[string]any), child)
+	}
 }
 
 func TestEasySlog(t *testing.T) {
@@ -68,16 +72,95 @@ func TestEasySlog(t *testing.T) {
 		return results
 	})
 
-	if err != nil {
-		t.Fatal(err)
+	require.NoError(t, err)
+}
+
+type FastJSONFormatter struct{}
+
+var _ Formatter = (*FastJSONFormatter)(nil)
+
+func (formatter FastJSONFormatter) Format(w io.Writer, record Record) error {
+	result := make(map[string]any, len(record.Attrs))
+	result["msg"] = record.Message
+	result["level"] = record.Level.String()
+
+	if !record.Time.IsZero() {
+		result["time"] = record.Time
 	}
+
+	var buf bytes.Buffer
+	buf.Write([]byte("{"))
+
+	buf.Write([]byte("\"msg\":\""))
+	buf.Write([]byte(record.Message))
+	buf.Write([]byte("\""))
+
+	buf.Write([]byte(",\"level\":\""))
+	buf.Write([]byte(record.Level.String()))
+	buf.Write([]byte("\""))
+
+	if !record.Time.IsZero() {
+		buf.Write([]byte(",\"time\":\""))
+		buf.Write([]byte(record.Time.String()))
+		buf.Write([]byte("\""))
+	}
+
+	for _, attr := range record.Attrs {
+		fastWriteAttr(&buf, attr, false)
+	}
+
+	buf.Write([]byte("}"))
+	_, _ = w.Write(buf.Bytes())
+	return nil
+}
+
+func fastWriteAttr(buf *bytes.Buffer, attr *Attr, first bool) {
+	if !first {
+		buf.Write([]byte(","))
+	}
+	if attr.Children == nil || len(attr.Children) == 0 {
+		buf.Write([]byte(`"`))
+		buf.Write([]byte(attr.Key))
+		buf.Write([]byte(`":`))
+
+		switch attr.Value.Kind() {
+		case slog.KindInt64, slog.KindFloat64, slog.KindUint64:
+			buf.Write([]byte(attr.Value.String()))
+		default:
+			buf.Write([]byte("\""))
+			buf.Write([]byte(attr.Value.String()))
+			buf.Write([]byte("\""))
+		}
+		return
+	}
+
+	buf.Write([]byte(`"`))
+	buf.Write([]byte(attr.Key))
+	buf.Write([]byte(`":`))
+
+	buf.Write([]byte("{"))
+	for i, child := range attr.Children {
+		fastWriteAttr(buf, child, i == 0)
+	}
+	buf.Write([]byte("}"))
 }
 
 func BenchmarkEasySlog(b *testing.B) {
-	formatter := JSONFormatter{}
+	formatter := FastJSONFormatter{}
 	handler := New(io.Discard, formatter, &Options{Level: slog.LevelDebug})
 
 	l := slog.New(handler)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		l.Info("hello")
+		l.With("foo", "bar").WithGroup("X-Files").With("Fox", "Mulder", "Dana", "Scully").Info("The truth is out there", "spooky", true)
+	}
+}
+
+func BenchmarkSlog(b *testing.B) {
+	l := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
 		l.Info("hello")

--- a/prettylog/prettylog_test.go
+++ b/prettylog/prettylog_test.go
@@ -16,9 +16,9 @@ func TestFormat(t *testing.T) {
 	handler := easyslog.New(&buf, Formatter{}, nil)
 	l := slog.New(handler)
 
-	l.Debug("omg", "foo", "bar", "baz", "quux")
+	l.Info("omg", "foo", "bar", "baz", "quux")
 
-	require.Equal(t, "[DBG] omg foo=bar baz=quux\n", buf.String())
+	require.Equal(t, "[INF] omg foo=bar baz=quux \n", buf.String())
 }
 
 func TestColorDisabled(t *testing.T) {
@@ -31,9 +31,9 @@ func TestColorDisabled(t *testing.T) {
 	handler := easyslog.New(&buf, Formatter{NoColor: true}, nil)
 	l := slog.New(handler)
 
-	l.Debug("omg", "foo", "bar", "baz", "quux")
+	l.Info("omg", "foo", "bar", "baz", "quux")
 
-	require.Equal(t, "[DBG] omg foo=bar baz=quux\n", buf.String())
+	require.Equal(t, "[INF] omg foo=bar baz=quux \n", buf.String())
 }
 
 func TestUnknownLogLevels(t *testing.T) {
@@ -43,5 +43,15 @@ func TestUnknownLogLevels(t *testing.T) {
 
 	l.Log(context.Background(), 7, "omg", "foo", "bar", "baz", "quux")
 
-	require.Equal(t, "[UNK] omg foo=bar baz=quux\n", buf.String())
+	require.Equal(t, "[UNK] omg foo=bar baz=quux \n", buf.String())
+}
+
+func TestGroups(t *testing.T) {
+	var buf bytes.Buffer
+	handler := easyslog.New(&buf, Formatter{}, nil)
+	l := slog.New(handler)
+
+	l.Info("msg", slog.Group("request", "method", "get", "path", "/"))
+
+	require.Equal(t, "[INF] msg request.method=get request.path=/ \n", buf.String())
 }


### PR DESCRIPTION
This changes the implementation to no longer return Attrs that have a
slice of keys and a value, but to give keys a `Children` property so
that they can be traversed in a tree-like fashion.

This better aligns with how structured logs work conceptually and
still provides an easier-to-use interface over the default slog
Handler interface for a minor performance penalty.
